### PR TITLE
Bump version of Rok8s scripts and store artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   slack: circleci/slack@4.4
-  rok8s-scripts: fairwinds/rok8s-scripts@11.1.1
+  rok8s-scripts: fairwinds/rok8s-scripts@11.9.1
 
 commands:
   set_environment_variables:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,3 +165,4 @@ workflows:
             - build_and_push_plugins
           pre_script: e2e/pre.sh
           script: e2e/ci.sh
+          store-artifacts: /workspace/output

--- a/e2e/test.sh
+++ b/e2e/test.sh
@@ -29,15 +29,18 @@ helm upgrade --install insights-agent fairwinds-stable/insights-agent \
   --set opa.image.tag="$opa_tag" \
   --set uploader.image.tag="$uploader_tag"
 
+kubectl -n insights-agent delete job workloads
 sleep 5
 kubectl get all --namespace insights-agent
-kubectl wait --for=condition=complete job/workloads --timeout=120s --namespace insights-agent
 kubectl wait --for=condition=complete job/rbac-reporter --timeout=120s --namespace insights-agent
 kubectl wait --for=condition=complete job/kube-bench --timeout=120s --namespace insights-agent
 kubectl wait --for=condition=complete job/trivy --timeout=480s --namespace insights-agent
 # TODO: enable OPA
 # kubectl wait --for=condition=complete job/opa --timeout=480s --namespace insights-agent
 kubectl wait --for=condition=complete job/kubesec --timeout=480s --namespace insights-agent
+kubectl -n insights-agent create job workloads --from=cronjob/workloads
+sleep 5
+kubectl wait --for=condition=complete job/workloads --timeout=120s --namespace insights-agent
 
 kubectl get jobs --namespace insights-agent
 echo "Testing kube-bench"


### PR DESCRIPTION
## Description
<!-- what this change does -->
Stores output files from e2e tests. If there's a failure then you can grab the JSON file that failed and bump it against the schema manually to try to figure out what's wrong with the schema file.

## Checklist

* [x] I have updated the CHANGELOG of any plugins updated
* [x] I have updated the version file of any plugins updated
* [x] I have added tests wherever appropriate
* [x] I have labeled this PR with a label per plugin updated
