### PR TITLE
Allow for multiple namespaces in Automation Rule example

### DIFF
--- a/plugins/automation/examples/working-as-intended-resolution.yaml
+++ b/plugins/automation/examples/working-as-intended-resolution.yaml
@@ -1,10 +1,13 @@
-name: "Don’t scan containers in the kube-system namespace"
-description: "Mark any action items in the kube-system namespace as working as intended"
+name: "Don’t scan containers in specific namespaces"
+description: "Mark any action items in specific namespace as working as intended"
 context: ""
 reportType: ""
 cluster: ""
 repository: ""
 action: |
-  if (ActionItem.ResourceNamespace === "kube-system") {
+  //Enumerate which namespaces you'd like to mark action items as working as indentend
+  var namespaceScope = ["kube-system","insights-agent"];
+  
+  if (namespaceScope.indexOf(ActionItem.ResourceNamespace) !== -1) {
       ActionItem.Resolution = WORKING_AS_INTENDED_RESOLUTION;
   }


### PR DESCRIPTION
This is a small change that will allow a user to more easily specify multiple namespaces they'd like to mark action items as working as intended. The added benefit here is, with no additional user changes, action items associated with insights-agent will also be marked (helping us further reduce information overload).

## Description
<!-- what this change does -->


## Checklist

* [ ] I have updated the CHANGELOG of any plugins updated
* [ ] I have updated the version file of any plugins updated
* [ ] I have added tests wherever appropriate
* [ ] I have labeled this PR with a label per plugin updated
