### PR TITLE
add scan-all script

### DIFF
--- a/scripts/scan-all.sh
+++ b/scripts/scan-all.sh
@@ -1,0 +1,18 @@
+#! /bin/bash
+set -eo pipefail
+
+for d in ./plugins/*/ ; do
+    if [[ $d == "_template" ]]; then
+      continue
+    fi
+    if [[ ! -f $d/build.config ]]; then
+      continue
+    fi
+    version=$(cat $d/version.txt)
+    . $d/build.config
+    name="quay.io/$REPOSITORY_NAME:$version"
+    echo "scanning $name"
+    docker pull $name
+    trivy $name
+done
+


### PR DESCRIPTION
This PR fixes issue #

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Have a way to scan all the current published versions of plugins in this repo

### What changes did you make?
Added a shell script

### What alternative solution should we consider, if any?
Would be nice to e.g. run this on a cronjob