### PR TITLE
Fix the `tail` command flag-order for `bump-change.sh`

### DIFF
--- a/scripts/bump-changed.sh
+++ b/scripts/bump-changed.sh
@@ -24,7 +24,7 @@ for d in ./plugins/*/ ; do
     echo -e "# Changelog" > /tmp/CHANGELOG.md
     echo -e "\n## $version" >> /tmp/CHANGELOG.md
     echo -e "* $message" >> /tmp/CHANGELOG.md
-    tail $d/CHANGELOG.md -n +2 >> /tmp/CHANGELOG.md
+    tail -n+2 $d/CHANGELOG.md >> /tmp/CHANGELOG.md
     mv /tmp/CHANGELOG.md $d/CHANGELOG.md
 done
 


### PR DESCRIPTION

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Fix the failing `tail` command (parsing the -n +2 as file names).
### What changes did you make?
Moved the arguments to the beginning of the command.
### What alternative solution should we consider, if any?

