### PR TITLE
Remove insights-ci.sh in favor of auto-scan

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,6 @@ jobs:
     executor: ci-images
     steps:
       - docker_build
-      - insights_test
       - slack/notify:
           event: fail
           branch_pattern: main
@@ -92,7 +91,6 @@ jobs:
     executor: ci-images-large
     steps:
       - docker_build
-      - insights_test
       - docker_push_plugins
       - slack/notify:
           event: fail


### PR DESCRIPTION
This PR fixes #

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Enable auto-scan by Insights

### What changes did you make?
Remove the script

### What alternative solution should we consider, if any?

