### PR TITLE
Use the `imageID` to get container images instead of `image`

### DIFF
--- a/plugins/trivy/pkg/image/getimages.go
+++ b/plugins/trivy/pkg/image/getimages.go
@@ -96,8 +96,16 @@ func GetImages(ctx context.Context) ([]models.Image, error) {
 		}
 
 		for _, containerStatus := range pod.Status.ContainerStatuses {
+			var imageName string
+			imageIDFields := strings.SplitN(containerStatus.ImageID, "@", 2) // split image from SHA
+			if len(imageIDFields) < 2 || imageIDFields[0] == "" {
+				logrus.Debugf("cannot split containerStatuses.imageID %q by @ to construct an image name, falling back to using imageStatuses.image", containerStatus.ImageID)
+				imageName = containerStatus.Image
+			} else {
+				imageName = strings.TrimPrefix(imageIDFields[0], "docker-pullable://")
+			}
 			im := models.Image{
-				Name:  containerStatus.Image,
+				Name:  imageName,
 				ID:    strings.TrimPrefix(containerStatus.ImageID, "docker-pullable://"),
 				Owner: models.Resource(owner),
 			}


### PR DESCRIPTION
Sometimes `image` only contains a SHA. This change aims to provide an image name in more cases.
If `imageID` cannot be split by an at-sign (@), the original `image` is used as a fallback.
## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Provide a name for Trivy image findings in cases where the `containerStatuses.*.image` field only contains a SHA.

### What changes did you make?
Use the `containerStatuses.*.imageID` field instead, splitting it by an at-sign (@) to remove the SHA, and removing the optional `DockerPullable` prefix.

### What alternative solution should we consider, if any?
We could attempt to use the Pod `spec.Containers.*.image` field however that array can be in a different order than `containerStatuses`.