### PR TITLE
FWI-4897 - Automatically rebuild insights-plugins/main on a regular interval

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -325,3 +325,15 @@ workflows:
             branches:
               only:
                 - main
+
+  rebuild:
+    triggers:
+      - schedule:
+          # At 00:00 every day monday-friday
+          cron: "0 0 * * 1-5"
+          filters:
+            branches:
+              only:
+                - main
+    jobs:
+      - build_and_push_plugins


### PR DESCRIPTION
This PR fixes #

reference: https://circleci.com/docs/migrate-scheduled-workflows-to-scheduled-pipelines/

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?

This adds a schedule to circleci that instructs it to automatically rebuild images on `main` every Tuesday

### What changes did you make?

### What alternative solution should we consider, if any?



[Internal Ticket FWI-4897](https://fairwinds.myjetbrains.com/youtrack/issue/FWI-4897)