### PR TITLE
FWI-1478 - Add insights_collect script

### DIFF
--- a/scripts/insights_collect.sh
+++ b/scripts/insights_collect.sh
@@ -1,0 +1,43 @@
+#! /bin/bash
+# file: insights_collect.sh
+# this is a simple bash script that collects job and pod data in the insights-agent namespace,
+# to assist customers with debugging of insights
+set -e
+# redirect output to a file for uploading later
+exec >> insights_collect_$(date +%s).log
+exec 2>&1
+NAMESPACE=insights-agent
+trap 'echo "Error on Line: $LINENO"' ERR
+
+echo "Collecting insights diagnostic information in namespace ${NAMESPACE}"
+
+kubectl -n ${NAMESPACE} get pods
+kubectl -n ${NAMESPACE} get jobs
+
+pods=$(kubectl -n ${NAMESPACE} get pods | tail -n +2 | awk '{print $1}')
+jobs=$(kubectl -n ${NAMESPACE} get jobs | tail -n +2 | awk '{print $1}')
+
+echo "found ${#pods[@]} pods in ${NAMESPACE}"
+echo "found ${#jobs[@]} jobs in ${NAMESPACE}"
+
+for pod_name in $pods; do
+    echo
+    echo "========================"
+    echo "pod_name=${pod_name}"
+    echo "========================"
+    echo
+    kubectl -n ${NAMESPACE} describe pod ${pod_name}
+    echo
+    kubectl -n ${NAMESPACE} logs -f ${pod_name} --all-containers=true
+done
+
+for job_name in $jobs; do
+    echo
+    echo "========================"
+    echo "job_name=${job_name}"
+    echo "========================"
+    echo
+    kubectl -n ${NAMESPACE} describe job ${job_name}
+    echo
+done
+


### PR DESCRIPTION
This PR fixes #

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description

Instructions:

Run `./insights_collect.sh` . This will simply get all pod and job statuses in the `insights-agent` namespace, as well as the logs for all pods in the namespace. This will assist our SREs and development team in debugging any potential issues with the insights agent in the customers cluster.
The script will write all of its output to a file that looks something like `insights_collect_1698788297.log` , where `1698788297` is the unix timestamp. Once the script finishes running, they can send us the log file for further inspection

### What's the goal of this PR?

User runs a command to use a script to get the following data and put it into a single text file (tarball) that they can send to the Fairwinds rep for troubleshooting
All Logs
Pod Statuses
Cronjob statuses
Document this script in the help documentation

### What changes did you make?

* Add the `insights_collect.sh` script

### What alternative solution should we consider, if any?

